### PR TITLE
Use .bash_profile instead of .profile

### DIFF
--- a/installer/unix/install-cli
+++ b/installer/unix/install-cli
@@ -14,7 +14,7 @@ BINARY="particle"
 DEST_PATH="$HOME/bin"
 DEST="$DEST_PATH/$BINARY"
 MANIFEST_URL="https://binaries.particle.io/cli/master/manifest.json"
-SHELL_CONFIG="$HOME/.profile"
+SHELL_CONFIG="$HOME/.bash_profile"
 
 # Compute OS and architecture
 UNAME=$(uname -s)


### PR DESCRIPTION
The file `~/.profile` gets ignored once a `~/.bash_profile` exists. Better to always use `~/.bash_profile` in the first place.
Problems occurred as I installed other CLIs (Google Cloud SDK)  which use `~/.bash_profile`.