### PR TITLE
bug/sc-103389/cli-install-m1-alert

### DIFF
--- a/installer/unix/install-cli
+++ b/installer/unix/install-cli
@@ -55,6 +55,15 @@ case $PROCESSOR in
         ;;
 esac
 
+# warn and exit if we're running on an Appple M1 processor
+if [ "$OS" = "darwin" ] && [ "$ARCH" == "arm" ]; then
+    echo "Apple M1 processor detected!"
+    echo "Particle CLI must be run under Rosetta"
+    echo "To enable Rosetta, see:"
+    echo "https://community.particle.io/t/apple-m1-support/59403/3"
+    exit 1
+fi
+
 # setup for legacy macOS bash
 if [ -e "$HOME/.profile" ] && [ "${OS}" == "darwin" ]; then
    SHELL_CONFIG="$HOME/.profile"


### PR DESCRIPTION
## Description

Adds a warning when run under Apple M1 cpu architecture. 


## How to Test

1. Using an Apple M1 machine...
2. Pull down this branch (`git pull && git checkout bug/sc-103389/cli-install-m1-alert`)
3. Disable "Open using Rosetta" for your terminal application ([example](https://community.particle.io/t/apple-m1-support/59403/3))
4. Run the install script: `./installer/unix/install-cli`
5. Verify that you are shown the alert starting with `Apple M1 processor detected!`
6. Enable "Open using Rosetta" for your terminal application ([example](https://community.particle.io/t/apple-m1-support/59403/3))
7. Re-run the install script: `./installer/unix/install-cli`
8. Verify that the CLI and its dependencies are installed successfully

**Outcome**

When run on an Apple M1 _without_ Rosetta enabled, the CLI install script shows an alert to the user instructing them to enable Rosetta. When run on an Apple M1 _with_ Rosetta enabled, the installation completes successfully. 

The alert looks like this:

```
PARTICLE CLI SETUP...

Apple M1 processor detected!
Particle CLI must be run under Rosetta
To enable Rosetta, see:
https://community.particle.io/t/apple-m1-support/59403/3
```


## Related / Discussions

https://app.shortcut.com/particle/story/103389/unable-to-install-particle-cli-following-the-install-guide-on-m1-mac