### PR TITLE
feat: [sc-118144] Update to Node 16 and check SHA256 for CLI wrapper

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.2.0] - 2023-05-03
+
+- Verify version updates using SHA256
+- Update backing Node.js version to `v16`
+
 ## [1.1.0] - 2020-03-18
 
 - Fix `upate-cli` command's native module handling

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,12 +4,13 @@ Prerequisites:
 
 * `gem install rake aws-sdk-s3`
 * `particle-cli-wrapper` repo
-* `PARTICLE_CLI_RELEASE_ACCESS` and `PARTICLE_CLI_RELEASE_SECRET` for the S3 repository
+* AWS access for the S3 bucket `mode-static-binaries-particle-io-20230314171309486000000003`
 
 Instructions:
 
 * Increment version
 * Update CHANGELOG
+* Provide AWS credentials by logging in to AWS through the browser, clicking  Command line or programmatic access and copy-pasting the short term credentials into the terminal
 * [optional] Update `beta` branch with latest changes.
 * [optional] Run `rake release` on beta branch to test changes.
 * [optional] macOS, Linux: Run `CHANNEL=beta bash <( curl -sL https://particle.io/install-cli )` to install the beta
@@ -29,7 +30,7 @@ Make sure the user with the S3 credentials above have these permissions.
                 "s3:ListBucket"
             ],
             "Resource": [
-                "arn:aws:s3:::binaries.particle.io"
+                "arn:aws:s3:::mode-static-binaries-particle-io-20230314171309486000000003"
             ]
         },
         {
@@ -41,7 +42,7 @@ Make sure the user with the S3 credentials above have these permissions.
                 "s3:PutObjectAcl"
             ],
             "Resource": [
-                "arn:aws:s3:::binaries.particle.io/*"
+                "arn:aws:s3:::mode-static-binaries-particle-io-20230314171309486000000003/*"
             ]
         }
     ]

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require 'json'
 
 PRODUCT_NAME = 'cli'
 BINARY_NAME = 'particle'
-BUCKET_NAME = 'binaries.particle.io'
+BUCKET_NAME = 'mode-static-binaries-particle-io-20230314171309486000000003'
 ASSETS_HOST = 'binaries.particle.io'
 
 TARGETS = [
@@ -22,10 +22,6 @@ dirty = `git status 2> /dev/null | tail -n1`.chomp != 'nothing to commit, workin
 CHANNEL = dirty ? 'dirty' : `git rev-parse --abbrev-ref HEAD`.chomp
 LABEL = "particle-cli-wrapper/#{VERSION} (#{CHANNEL})"
 REVISION=`git log -n 1 --pretty=format:"%H"`
-
-task :sha do
-  puts sha_digest("dist/linux/amd64/particle")
-end
 
 task :manifest do
   puts JSON.dump(manifest)
@@ -139,7 +135,7 @@ def manifest
 end
 
 def s3_client
-  @s3_client ||= Aws::S3::Client.new(region: 'us-east-1', access_key_id: ENV['PARTICLE_CLI_RELEASE_ACCESS'], secret_access_key: ENV['PARTICLE_CLI_RELEASE_SECRET'])
+  @s3_client ||= Aws::S3::Client.new(region: 'us-east-1', access_key_id: ENV['PARTICLE_CLI_RELEASE_ACCESS'], secret_access_key: ENV['PARTICLE_CLI_RELEASE_SECRET'], session_token: ENV['PARTICLE_CLI_RELEASE_SESSION_TOKEN'])
 end
 
 def upload_file(local, remote, opts={})

--- a/Rakefile
+++ b/Rakefile
@@ -135,7 +135,7 @@ def manifest
 end
 
 def s3_client
-  @s3_client ||= Aws::S3::Client.new(region: 'us-east-1', access_key_id: ENV['PARTICLE_CLI_RELEASE_ACCESS'], secret_access_key: ENV['PARTICLE_CLI_RELEASE_SECRET'], session_token: ENV['PARTICLE_CLI_RELEASE_SESSION_TOKEN'])
+  @s3_client ||= Aws::S3::Client.new(region: 'us-east-1', access_key_id: ENV['AWS_ACCESS_KEY_ID'], secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'], session_token: ENV['AWS_SESSION_TOKEN'])
 end
 
 def upload_file(local, remote, opts={})

--- a/Rakefile
+++ b/Rakefile
@@ -54,6 +54,7 @@ task :release => :build do
     upload_file(from, to, content_type: 'binary/octet-stream', cache_control: cache_control)
     upload_file(from + '.gz', to + '.gz', content_type: 'binary/octet-stream', content_encoding: 'gzip', cache_control: cache_control)
     upload(sha_digest(from), to + ".sha1", content_type: 'text/plain', cache_control: cache_control)
+    upload(sha256_digest(from), to + ".sha256", content_type: 'text/plain', cache_control: cache_control)
   end
   upload_manifest()
   puts "Released #{VERSION}"
@@ -99,6 +100,10 @@ def sha_digest(path)
   Digest::SHA1.file(path).hexdigest
 end
 
+def sha256_digest(path)
+  Digest::SHA256.file(path).hexdigest
+end
+
 def local_path(os, arch)
   ext = ".exe" if os === 'windows'
   "./dist/#{os}/#{arch}/#{BINARY_NAME}#{ext}"
@@ -125,7 +130,8 @@ def manifest
     @manifest[:builds][target[:os]] ||= {}
     @manifest[:builds][target[:os]][target[:arch]] = {
       url: remote_url(target[:os], target[:arch]),
-      sha1: sha_digest(local_path(target[:os], target[:arch]))
+      sha1: sha_digest(local_path(target[:os], target[:arch])),
+      sha256: sha256_digest(local_path(target[:os], target[:arch])),
     }
   end
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/particle-iot/particle-cli-wrapper
+
+go 1.20
+
+require github.com/franela/goreq v0.0.0-20160121145150-3ddeded65be2
+
+require (
+	github.com/franela/goblin v0.0.0-20211003143422-0a4f594942bf // indirect
+	github.com/onsi/gomega v1.27.6 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/franela/goblin v0.0.0-20211003143422-0a4f594942bf h1:NrF81UtW8gG2LBGkXFQFqlfNnvMt9WdB46sfdJY4oqc=
+github.com/franela/goblin v0.0.0-20211003143422-0a4f594942bf/go.mod h1:VzmDKDJVZI3aJmnRI9VjAn9nJ8qPPsN1fqzr9dqInIo=
+github.com/franela/goreq v0.0.0-20160121145150-3ddeded65be2 h1:XBXjXjmO+l2OU6rG7HJTH4rxmuJ/NbyhzwXMRGHGLLY=
+github.com/franela/goreq v0.0.0-20160121145150-3ddeded65be2/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
+github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
+golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
+golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/gode/constants.go
+++ b/gode/constants.go
@@ -12,7 +12,7 @@ const Version = "16.20.0"
 // NpmVersion is the requested npm version
 const NpmVersion = "8.19.4"
 
-const npmSha = "1af70b2cafbea9a24eed6ba62a11eebf5ff0a54b6176c22ac21b891b79bcc5ad"
+const npmSha = "d03c2f6bac56dc3cd53a1e7a2ccc2ee0081531c97fed69b694d2b93bc16de43d"
 const npmURL = "https://binaries.particle.io/npm/v8.19.4.zip"
 
 var targets = []Target{

--- a/gode/constants.go
+++ b/gode/constants.go
@@ -7,18 +7,18 @@ package gode
 //
 
 // Version is the requested node version
-const Version = "12.16.1"
+const Version = "16.20.0"
 
 // NpmVersion is the requested npm version
-const NpmVersion = "6.13.7"
+const NpmVersion = "8.19.4"
 
-const npmSha = "8b4af16d3b42cd8a3faaa6d87b20eae1f878863d30e2991989f3f42c9898b441"
-const npmURL = "https://binaries.particle.io/npm/v6.13.7.zip"
+const npmSha = "1af70b2cafbea9a24eed6ba62a11eebf5ff0a54b6176c22ac21b891b79bcc5ad"
+const npmURL = "https://binaries.particle.io/npm/v8.19.4.zip"
 
 var targets = []Target{
-	{"amd64", "linux", "https://binaries.particle.io/node/v12.16.1/node-v12.16.1-linux-x64.tar.gz", "node-v12.16.1-linux-x64", "b2d9787da97d6c0d5cbf24c69fdbbf376b19089f921432c5a61aa323bc070bea"},
-	{"arm", "linux", "https://binaries.particle.io/node/v12.16.1/node-v12.16.1-linux-armv7l.tar.gz", "node-v12.16.1-linux-armv7l", "d418d0516dfd744a8109e4ed58b021e3a1babb64baed2ebc30e613df97c643fb"},
-	{"amd64", "darwin", "https://binaries.particle.io/node/v12.16.1/node-v12.16.1-darwin-x64.tar.gz", "node-v12.16.1-darwin-x64", "34895bce210ca4b3cf19cd480e6563588880dd7f5d798f3782e3650580d35920"},
-	{"386", "windows", "https://binaries.particle.io/node/v12.16.1/win-x86/node.exe", "node-v12.16.1-windows-x86", "78fa91d73172df8e10e1824394087a9d6409259fdc3bd5a83fa90d53e4edb6a6"},
-	{"amd64", "windows", "https://binaries.particle.io/node/v12.16.1/win-x64/node.exe", "node-v12.16.1-windows-x64", "3f8dabbe93d05367035df2078cb72a20c1b74cf1b41648ea91d902825902fcee"},
+	{"amd64", "linux", "https://binaries.particle.io/node/v16.20.0/node-v16.20.0-linux-x64.tar.gz", "node-v16.20.0-linux-x64", "7abc0e558fa3b3c4cc0fd3c7fa5dbe61500ba7213f5e87ed560c65a733c6a5c4"},
+	{"arm", "linux", "https://binaries.particle.io/node/v16.20.0/node-v16.20.0-linux-armv7l.tar.gz", "node-v16.20.0-linux-armv7l", "01f71cca760c2e3ee0178c29dc7352a579f4a006ba8d628744dcd82b126b1fad"},
+	{"amd64", "darwin", "https://binaries.particle.io/node/v16.20.0/node-v16.20.0-darwin-x64.tar.gz", "node-v16.20.0-darwin-x64", "263d5b4871972028e204087fc8a67e21d8a0e2a420d1247375089ec8fd12759e"},
+	{"386", "windows", "https://binaries.particle.io/node/v16.20.0/win-x86/node.exe", "node-v16.20.0-windows-x86", "029343acebfbe9b9f858da0e68bc532878a8844a7f59e7451668059f72e49f0f"},
+	{"amd64", "windows", "https://binaries.particle.io/node/v16.20.0/win-x64/node.exe", "node-v16.20.0-windows-x64", "a49f9e852f80cfc00ddcd75dcfccbe2987672f78dcbf7f5454a832479c77f448"},
 }

--- a/gode/packages.go
+++ b/gode/packages.go
@@ -34,6 +34,11 @@ func Packages() ([]Package, error) {
 	return packages, nil
 }
 
+// RemovePackageLock removes the package-lock.json file
+func RemovePackageLock() error {
+    return os.Remove(filepath.Join(rootPath, "package-lock.json"))
+}
+
 // InstallPackages installs a npm packages.
 func InstallPackages(packages ...string) error {
 	args := append([]string{"install", "--force"}, packages...)

--- a/installer/unix/install-cli
+++ b/installer/unix/install-cli
@@ -101,7 +101,7 @@ TMP_FILE=$(mktemp)
 
 curl -s "$BINARY_URL.gz" | gunzip > "$TMP_FILE"
 
-echo "$BINARY_SHA256  $TMP_FILE" | sha256sum -c > /dev/null 2>&1
+echo "$BINARY_SHA256  $TMP_FILE" | shasum a 256 -c > /dev/null 2>&1
 if [ $? -eq 1 ]; then
    echo ':::: Checksum check failed! Aborting installation'
    exit 1

--- a/installer/unix/install-cli
+++ b/installer/unix/install-cli
@@ -93,16 +93,21 @@ fi
 echo ":::: Installing the Particle CLI for $OS to \"$DEST\""
 
 BINARY_URL=$(curl -s $MANIFEST_URL | $PYTHON -c "import sys, json; print(json.load(sys.stdin)['builds']['$OS']['$ARCH']['url'])")
+BINARY_SHA256=$(curl -s $MANIFEST_URL | $PYTHON -c "import sys, json; print(json.load(sys.stdin)['builds']['$OS']['$ARCH']['sha256'])")
 
-# Download binary
+# Download and validate binary
 mkdir -p "$DEST_PATH"
+TMP_FILE=$(mktemp)
 
-if [ -z "$LOCAL_BINARY" ]; then
-    curl -s "$BINARY_URL.gz" | gunzip > "$DEST"
-else
-    cp "$LOCAL_BINARY" "$DEST"
+curl -s "$BINARY_URL.gz" | gunzip > "$TMP_FILE"
+
+echo "$BINARY_SHA256  $TMP_FILE" | sha256sum -c > /dev/null 2>&1
+if [ $? -eq 1 ]; then
+   echo ':::: Checksum check failed! Aborting installation'
+   exit 1
 fi
 
+mv -f "$TMP_FILE" "$DEST"
 chmod +x "$DEST"
 
 # Run binary for the first time to make it install Node and the

--- a/plugin_cache.go
+++ b/plugin_cache.go
@@ -7,6 +7,7 @@ import (
 )
 
 var pluginCachePath = filepath.Join(AppDir(), "plugin-cache.json")
+var packageJsonPath = filepath.Join(AppDir(), "package.json")
 
 // AddPluginsToCache adds/updates a set of plugins to ~/.particle/plugin-cache.json
 func AddPluginsToCache(plugins ...*Plugin) {
@@ -42,6 +43,11 @@ func FetchPluginCache() map[string]*Plugin {
 	if exists, _ := fileExists(pluginCachePath); !exists {
 		return plugins
 	}
+	// plugin-cache.json is redundant with package.json but we're not removing it now to avoid the chore
+	// if package.json is missing, assume that no plugins are installed correctly
+	if exists, _ := fileExists(packageJsonPath); !exists {
+	    return plugins
+    }
 	f, err := os.Open(pluginCachePath)
 	if err != nil {
 		return plugins

--- a/plugins.go
+++ b/plugins.go
@@ -81,15 +81,10 @@ func isPluginSymlinked(plugin string) bool {
 	return fi.Mode()&os.ModeSymlink != 0
 }
 
-func hasPackageJson() bool {
-    _, err := os.Stat(filepath.Join(AppDir(), "package.json"))
-    return err == nil
-}
-
 // ensure all the Javascript plugin are installed
 func SetupPlugins(pluginNames ...string) {
 	newPluginNames := difference(pluginNames, PluginNames())
-	if len(newPluginNames) == 0 && hasPackageJson() {
+	if len(newPluginNames) == 0 {
 		return
 	}
 	Err("particle: Installing plugins...")
@@ -131,11 +126,7 @@ func installPlugins(names ...string) error {
 			unlockPlugin(name)
 		}
 	}()
-	err := gode.RemovePackageLock()
-	if err != nil {
-		return err
-	}
-	err = gode.InstallPackages(names...)
+	err := gode.InstallPackages(names...)
 	if err != nil {
 		return err
 	}

--- a/plugins.go
+++ b/plugins.go
@@ -131,7 +131,11 @@ func installPlugins(names ...string) error {
 			unlockPlugin(name)
 		}
 	}()
-	err := gode.InstallPackages(names...)
+	err := gode.RemovePackageLock()
+	if err != nil {
+		return err
+	}
+	err = gode.InstallPackages(names...)
 	if err != nil {
 		return err
 	}

--- a/plugins.go
+++ b/plugins.go
@@ -81,10 +81,15 @@ func isPluginSymlinked(plugin string) bool {
 	return fi.Mode()&os.ModeSymlink != 0
 }
 
+func hasPackageJson() bool {
+    _, err := os.Stat(filepath.Join(AppDir(), "package.json"))
+    return err == nil
+}
+
 // ensure all the Javascript plugin are installed
 func SetupPlugins(pluginNames ...string) {
 	newPluginNames := difference(pluginNames, PluginNames())
-	if len(newPluginNames) == 0 {
+	if len(newPluginNames) == 0 && hasPackageJson() {
 		return
 	}
 	Err("particle: Installing plugins...")

--- a/set-node-version
+++ b/set-node-version
@@ -1,23 +1,27 @@
 #!/usr/bin/env node
 /*
- * Install s3 with
- * npm install s3
+ * Run with Node 16
+ * nvm use 16
+ *
+ * Install @aws-sdk/client-s3 with
+ * npm install @aws-sdk/client-s3
+ *
+ * Log in to AWS with
+ * aws sso login
  */
 'use strict';
 
-let bucket = 'binaries.particle.io';
+let bucket = 'mode-static-binaries-particle-io-20230314171309486000000003';
 let assetsHost = 'binaries.particle.io';
 
 let crypto = require('crypto');
 let fs     = require('fs');
 let https  = require('https');
-let s3client   = require('s3').createClient({
-  s3Options: {
-    accessKeyId:     process.env.PARTICLE_CLI_RELEASE_ACCESS,
-    secretAccessKey: process.env.PARTICLE_CLI_RELEASE_SECRET,
-    region: 'us-east-1',
-  }
-});
+const {
+  S3Client,
+  PutObjectCommand
+} = require('@aws-sdk/client-s3');
+const s3Client = new S3Client({ region: 'us-east-1' });
 
 // CHANGE THESE ONLY AND RUN SCRIPT
 // See https://nodejs.org/en/download/releases/ for valid values
@@ -65,23 +69,17 @@ function download (url, path) {
 
 function s3upload (local, remote) {
   let key = remote.replace(`https://${assetsHost}/`, '');
-  return new Promise(function (fulfill, reject) {
-    const uploader = s3client.uploadFile({
-      localFile: local,
-      s3Params: {
-        Bucket: bucket,
-        Key: key,
-        Metadata: {
-          'x-amz-acl': 'public-read',
-          'x-amz-meta-Cache-Control': 'public,max-age=86400',
-          'Cache-Control': 'public,max-age=86400',
-        }
-      }
-    });
-
-    uploader.on('error', reject);
-    uploader.on('end', fulfill);
-  });
+  const bucketParams = {
+    Bucket: bucket,
+    Body: fs.readFileSync(local),
+    Key: key,
+    Metadata: {
+      'x-amz-acl': 'public-read',
+      'x-amz-meta-Cache-Control': 'public,max-age=86400',
+      'Cache-Control': 'public,max-age=86400',
+    }
+  };
+  return s3Client.send(new PutObjectCommand(bucketParams));
 }
 
 function processTarget(target) {
@@ -104,7 +102,7 @@ function processNpm() {
   .then(()    => sha(path))
   .then((sha) => npmSha = sha)
   .then(function () {
-    npmURL = npmURL.replace('https://github.com/npm/npm/archive/', 'https://' + assetsHost + '/npm/');
+    npmURL = npmURL.replace('https://github.com/npm/cli/archive/', 'https://' + assetsHost + '/npm/');
     console.log(`Uploading ${npmURL}`);
     return s3upload(path, npmURL);
   });

--- a/set-node-version
+++ b/set-node-version
@@ -26,8 +26,8 @@ const s3Client = new S3Client({ region: 'us-east-1' });
 // CHANGE THESE ONLY AND RUN SCRIPT
 // See https://nodejs.org/en/download/releases/ for valid values
 // ==========================
-const version = '12.16.1';
-const npmVersion = '6.13.7';
+const version = '16.20.0';
+const npmVersion = '8.19.4';
 // ==========================
 
 const outputPath = '/./gode/constants.go';

--- a/set-node-version
+++ b/set-node-version
@@ -6,8 +6,8 @@
  * Install @aws-sdk/client-s3 with
  * npm install @aws-sdk/client-s3
  *
- * Log in to AWS with
- * aws sso login
+ * Provide AWS credentials by logging in to AWS through the browser, clicking  Command line or programmatic access
+ * and copy-pasting the short term credentials into the terminal
  */
 'use strict';
 

--- a/set-node-version
+++ b/set-node-version
@@ -17,6 +17,7 @@ let assetsHost = 'binaries.particle.io';
 let crypto = require('crypto');
 let fs     = require('fs');
 let https  = require('https');
+let child_process = require('child_process');
 const {
   S3Client,
   PutObjectCommand
@@ -82,6 +83,15 @@ function s3upload (local, remote) {
   return s3Client.send(new PutObjectCommand(bucketParams));
 }
 
+function exec(cmd) {
+  return new Promise(function (fulfill, reject) {
+    child_process.exec(cmd, function (err, stdout) {
+      if (err) return reject(err);
+      fulfill(stdout);
+    });
+  });
+}
+
 function processTarget(target) {
   let path = `./tmp/${target.arch}-${target.os}-v${version}`;
   console.log(`Downloading ${target.url}`);
@@ -97,8 +107,15 @@ function processTarget(target) {
 
 function processNpm() {
   let path = './tmp/npm.zip';
+  let unzipPath = './tmp/npm';
+  let noLinksPath = './tmp/npm-no-links';
+  let zipPath = '../npm.zip';
   console.log(`Downloading ${npmURL}`);
   return download(npmURL, path)
+    // unzip, copy to remove symbolic links and re-zip
+  .then(() => exec(`rm -rf ${unzipPath} && unzip -q ${path} -d ${unzipPath}`))
+  .then(() => exec(`rm -rf ${noLinksPath} && cp -L -R ${unzipPath} ${noLinksPath}`))
+  .then(() => exec(`rm ${path} && cd ${noLinksPath} && zip -q -r ${zipPath} .`))
   .then(()    => sha(path))
   .then((sha) => npmSha = sha)
   .then(function () {

--- a/update.go
+++ b/update.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"crypto/sha1"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -118,7 +118,7 @@ func updateCLI(channel string) {
 	if err := downloadBin(binPath+".new", build.URL); err != nil {
 		panic(err)
 	}
-	if fileSha1(binPath+".new") != build.Sha1 {
+	if fileSha256(binPath+".new") != build.Sha256 {
 		panic("SHA mismatch")
 	}
 	os.Remove(binPath + ".old")
@@ -167,7 +167,7 @@ func clearAutoupdateFile() {
 type manifest struct {
 	Channel, Version string
 	Builds           map[string]map[string]struct {
-		URL, Sha1 string
+		URL, Sha256 string
 	}
 }
 
@@ -206,12 +206,12 @@ func downloadBin(path, url string) error {
 	return err
 }
 
-func fileSha1(path string) string {
+func fileSha256(path string) string {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		panic(err)
 	}
-	return fmt.Sprintf("%x", sha1.Sum(data))
+	return fmt.Sprintf("%x", sha256.Sum256(data))
 }
 
 // TriggerBackgroundUpdate will trigger an update to the client in the background

--- a/version
+++ b/version
@@ -1,3 +1,3 @@
 #!/bin/sh
 SHA=`git rev-parse --short HEAD`
-echo 1.1.0-$SHA
+echo 1.2.0-$SHA


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/118144

During the wrapper install and upgrade, check the new binary using SHA256 instead of SHA1.

Also take this opportunity to update the Node version used to run the CLI to Node 16.

Steps to test:
- Install the beta channel with `CHANNEL=beta ./install-cli`
- Run the Validation steps in the README